### PR TITLE
修改了向 redis 写入数据时程序崩溃的问题

### DIFF
--- a/src/slave/rs_mysql_test_test.c
+++ b/src/slave/rs_mysql_test_test.c
@@ -62,7 +62,7 @@ static int rs_insert_test_test(rs_slave_info_t *si, void *obj)
 
     test = (rs_mysql_test_t *) obj;
 
-    if(rs_redis_append_command(si, "SET test_%d %s", test->id, test->col) 
+    if(rs_redis_append_command(si, "SET test_%d %s", test->id, test->col.data) 
             != RS_OK)
     {
         return RS_ERR;


### PR DESCRIPTION
将 rs_pstr_t 当作字符串传给 redisvAppendCommand 函数了。
